### PR TITLE
feat: configure launch command

### DIFF
--- a/contents/config/config.qml
+++ b/contents/config/config.qml
@@ -1,0 +1,9 @@
+import org.kde.plasma.configuration
+
+ConfigModel {
+    ConfigCategory {
+        name: i18n("General")
+        icon: "configure"
+        source: "config/ConfigGeneral.qml"
+    }
+}

--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kcfg xmlns="http://www.kde.org/standards/kcfg/1.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
+                          http://www.kde.org/standards/kcfg/1.0/kcfg.xsd">
+
+    <kcfgfile name="plasmarc"/>
+
+    <group name="General">
+        <entry name="launchCommand" type="String">
+            <label>Launch Command</label>
+            <default>plasma-systemmonitor</default>
+        </entry>
+    </group>
+</kcfg>

--- a/contents/ui/config/ConfigGeneral.qml
+++ b/contents/ui/config/ConfigGeneral.qml
@@ -1,0 +1,20 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls as QQC2
+import org.kde.kcmutils as KCM
+import org.kde.kirigami as Kirigami
+
+KCM.SimpleKCM {
+    property alias cfg_launchCommand: launchCommand.text
+
+    Kirigami.FormLayout {
+        id: configItem
+
+        QQC2.TextField {
+            id: launchCommand
+            Kirigami.FormData.label: i18n("Launch Command")
+            placeholderText: i18n("Enter your launch command")
+            Layout.fillWidth: true
+        }
+    }
+}

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -149,7 +149,8 @@ PlasmoidItem {
     MouseArea {
         anchors.fill: root
         anchors.margins: -10
-        onClicked: executable.exec("plasma-systemmonitor")
+        onClicked: {
+            executable.exec(plasmoid.configuration.launchCommand ?? "plasma-systemmonitor")
+        }
     }
-
 }


### PR DESCRIPTION
This commit adds an option to change which app is launched upon left-click on the applet.

User can simply type the command that they want to be executed instead of the default `plasma-systemmonitor`.